### PR TITLE
fix multiline commands

### DIFF
--- a/docs/getting_started/create_account.md
+++ b/docs/getting_started/create_account.md
@@ -19,7 +19,7 @@ To create an account, type the following command below:
     ```
 === "Windows"
     ```PowerShell
-    pchain_client.exe keys create --name <NAME>
+    ./pchain_client.exe keys create --name <NAME>
     ```
 
 You will be asked to input your password to save the new keypair.
@@ -52,7 +52,7 @@ You can check the account balance using the account address (public key).
     ```
 === "Windows"
     ```PowerShell
-    pchain_client.exe query balance --address <PUBLIC_KEY>
+    ./pchain_client.exe query balance --address <PUBLIC_KEY>
     ```
 <details><summary>Terminal Output</summary>
 ```bash
@@ -74,7 +74,7 @@ To secure your keypair and money, you must export it and save it somewhere secur
     ```
 === "Windows"
     ```PowerShell
-    pchain_client.exe keys export --name <NAME>
+    ./pchain_client.exe keys export --name <NAME>
     ```
 
 You will be asked to input your password to export the keypair. The keypair will be saved in the current directory, in JSON format, with the same name as the keypair itself.
@@ -88,7 +88,7 @@ To add your keypair, type the following command below:
     ```
 === "Windows"
     ```PowerShell
-    pchain_client.exe keys import --public <PUBLIC_KEY> --private <PRIVATE_KEY> --name <NAME>
+    ./pchain_client.exe keys import --public <PUBLIC_KEY> --private <PRIVATE_KEY> --name <NAME>
     ```
 
 You will be asked to input your password to import the new keypair.

--- a/docs/getting_started/prepare_env.md
+++ b/docs/getting_started/prepare_env.md
@@ -78,9 +78,9 @@ After installation of `pchain_client`, you had to update the Mainnet / Testnet e
 === "Windows"
     ```PowerShell
     # Mainnet
-    pchain_client.exe config setup --url https://pchain-main-rpc02.parallelchain.io
+    ./pchain_client.exe config setup --url https://pchain-main-rpc02.parallelchain.io
     # Testnet
-    pchain_client.exe config setup --url https://pchain-test-rpc02.parallelchain.io
+    ./pchain_client.exe config setup --url https://pchain-test-rpc02.parallelchain.io
     ```
 
 This command will write a `config.toml` file in the folder specified by the environment variable `PCHAIN_CLI_HOME`. It only needs to be executed once.

--- a/docs/getting_started/staking.md
+++ b/docs/getting_started/staking.md
@@ -17,7 +17,7 @@ First, before you stake, you have to lock up (stake) some balance tied to an ope
 === "Linux / macOS"
     ```bash
     ./pchain_client transaction create \
-    --nonce <NONCE> \ 
+    --nonce <NONCE> \
     --gas-limit <GAS_LIMIT> \
     --max-base-fee-per-gas <MAX_BASE_FEE_PER_GAS> \
     --priority-fee-per-gas <PRIORITY_FEE_PER_GAS> \
@@ -28,14 +28,14 @@ First, before you stake, you have to lock up (stake) some balance tied to an ope
     ```
 === "Windows"
     ```PowerShell
-    pchain_client.exe transaction create \
-    --nonce <NONCE> \ 
-    --gas-limit <GAS_LIMIT> \
-    --max-base-fee-per-gas <MAX_BASE_FEE_PER_GAS> \
-    --priority-fee-per-gas <PRIORITY_FEE_PER_GAS> \ 
-    deposit create \
-    --operator <OPERATOR_ADDRESS> \
-    --balance <BALANCE> \
+    ./pchain_client.exe transaction create `
+    --nonce <NONCE> `
+    --gas-limit <GAS_LIMIT> `
+    --max-base-fee-per-gas <MAX_BASE_FEE_PER_GAS> `
+    --priority-fee-per-gas <PRIORITY_FEE_PER_GAS> `
+    deposit create `
+    --operator <OPERATOR_ADDRESS> `
+    --balance <BALANCE> `
     --auto-stake-rewards
     ```
 The last flag for `auto-stake-rewards` is optional. By default, it is false. It indicates whether your rewards should be staked to the Pool in each epoch.
@@ -57,7 +57,7 @@ After creating a Deposit in a Pool, use the CLI subcommands `deposit top-up` if 
 === "Linux / macOS"
     ```bash
     ./pchain_client transaction create \
-    --nonce <NONCE> \ 
+    --nonce <NONCE> \
     --gas-limit <GAS_LIMIT> \
     --max-base-fee-per-gas <MAX_BASE_FEE_PER_GAS> \
     --priority-fee-per-gas <PRIORITY_FEE_PER_GAS> \
@@ -67,13 +67,13 @@ After creating a Deposit in a Pool, use the CLI subcommands `deposit top-up` if 
     ```
 === "Windows"
     ```PowerShell
-    pchain_client.exe transaction create \
-    --nonce <NONCE> \ 
-    --gas-limit <GAS_LIMIT> \
-    --max-base-fee-per-gas <MAX_BASE_FEE_PER_GAS> \
-    --priority-fee-per-gas <PRIORITY_FEE_PER_GAS> \ 
-    deposit top-up \
-    --operator <OPERATOR_ADDRESS> \
+    ./pchain_client.exe transaction create `
+    --nonce <NONCE> `
+    --gas-limit <GAS_LIMIT> `
+    --max-base-fee-per-gas <MAX_BASE_FEE_PER_GAS> `
+    --priority-fee-per-gas <PRIORITY_FEE_PER_GAS> `
+    deposit top-up `
+    --operator <OPERATOR_ADDRESS> `
     --amount <AMOUNT>
     ```
 
@@ -85,7 +85,7 @@ You specified the flag `auto-stake-rewards` when you created the Deposit. You ca
 === "Linux / macOS"
     ```bash
     ./pchain_client transaction create \
-    --nonce <NONCE> \ 
+    --nonce <NONCE> \
     --gas-limit <GAS_LIMIT> \
     --max-base-fee-per-gas <MAX_BASE_FEE_PER_GAS> \
     --priority-fee-per-gas <PRIORITY_FEE_PER_GAS> \
@@ -95,13 +95,13 @@ You specified the flag `auto-stake-rewards` when you created the Deposit. You ca
     ```
 === "Windows"
     ```PowerShell
-    pchain_client.exe transaction create \
-    --nonce <NONCE> \ 
-    --gas-limit <GAS_LIMIT> \
-    --max-base-fee-per-gas <MAX_BASE_FEE_PER_GAS> \
-    --priority-fee-per-gas <PRIORITY_FEE_PER_GAS> \ 
-    deposit update-settings \
-    --operator <OPERATOR_ADDRESS> \
+    ./pchain_client.exe transaction create `
+    --nonce <NONCE> `
+    --gas-limit <GAS_LIMIT> `
+    --max-base-fee-per-gas <MAX_BASE_FEE_PER_GAS> `
+    --priority-fee-per-gas <PRIORITY_FEE_PER_GAS> `
+    deposit update-settings `
+    --operator <OPERATOR_ADDRESS> `
     --auto-stake-rewards
     ```
 
@@ -113,7 +113,7 @@ After you create a Deposit to a Pool, you should now stake some amount of it to 
 === "Linux / macOS"
     ```bash
     ./pchain_client transaction create \
-    --nonce <NONCE> \ 
+    --nonce <NONCE> \
     --gas-limit <GAS_LIMIT> \
     --max-base-fee-per-gas <MAX_BASE_FEE_PER_GAS> \
     --priority-fee-per-gas <PRIORITY_FEE_PER_GAS> \
@@ -123,13 +123,13 @@ After you create a Deposit to a Pool, you should now stake some amount of it to 
     ```
 === "Windows"
     ```PowerShell
-    pchain_client.exe transaction create \
-    --nonce <NONCE> \ 
-    --gas-limit <GAS_LIMIT> \
-    --max-base-fee-per-gas <MAX_BASE_FEE_PER_GAS> \
-    --priority-fee-per-gas <PRIORITY_FEE_PER_GAS> \ 
-    stake stake \
-    --operator <OPERATOR_ADDRESS> \
+    ./pchain_client.exe transaction create `
+    --nonce <NONCE> `
+    --gas-limit <GAS_LIMIT> `
+    --max-base-fee-per-gas <MAX_BASE_FEE_PER_GAS> `
+    --priority-fee-per-gas <PRIORITY_FEE_PER_GAS> `
+    stake stake `
+    --operator <OPERATOR_ADDRESS> `
     --max-amount <MAX_AMOUNT>
     ```
 
@@ -140,7 +140,7 @@ You can also unstake your stake on with the CLI subcommand `stake unstake`.
 === "Linux / macOS"
     ```bash
     ./pchain_client transaction create \
-    --nonce <NONCE> \ 
+    --nonce <NONCE> \
     --gas-limit <GAS_LIMIT> \
     --max-base-fee-per-gas <MAX_BASE_FEE_PER_GAS> \
     --priority-fee-per-gas <PRIORITY_FEE_PER_GAS> \
@@ -150,11 +150,11 @@ You can also unstake your stake on with the CLI subcommand `stake unstake`.
     ```
 === "Windows"
     ```PowerShell
-    pchain_client.exe transaction create
-    --nonce <NONCE> \ 
+    ./pchain_client.exe transaction create
+    --nonce <NONCE> \
     --gas-limit <GAS_LIMIT> \
     --max-base-fee-per-gas <MAX_BASE_FEE_PER_GAS> \
-    --priority-fee-per-gas <PRIORITY_FEE_PER_GAS> \ 
+    --priority-fee-per-gas <PRIORITY_FEE_PER_GAS> \
     stake unstake \
     --operator <OPERATOR_ADDRESS> \
     --max-amount <MAX_AMOUNT>
@@ -176,10 +176,10 @@ Suppose you created the transaction file (i.e. `tx.json`) from the step [Creatin
     ```
 === "Windows"
     ```PowerShell
-    pchain_client.exe transaction append \
-    --file <PATH_TO_TRANSACTION_FILE> \
-    stake stake \
-    --operator <OPERATOR_ADDRESS> \
+    ./pchain_client.exe transaction append `
+    --file <PATH_TO_TRANSACTION_FILE> `
+    stake stake `
+    --operator <OPERATOR_ADDRESS> `
     --max-amount <MAX_AMOUNT>
     ```
 
@@ -193,7 +193,7 @@ Your Deposit can be increased due to reward distribution in each epoch. If you w
 === "Linux / macOS"
     ```bash
     ./pchain_client transaction create
-    --nonce <NONCE> \ 
+    --nonce <NONCE> \
     --gas-limit <GAS_LIMIT> \
     --max-base-fee-per-gas <MAX_BASE_FEE_PER_GAS> \
     --priority-fee-per-gas <PRIORITY_FEE_PER_GAS> \
@@ -203,11 +203,11 @@ Your Deposit can be increased due to reward distribution in each epoch. If you w
     ```
 === "Windows"
     ```PowerShell
-    pchain_client.exe transaction create
-    --nonce <NONCE> \ 
+    ./pchain_client.exe transaction create
+    --nonce <NONCE> \
     --gas-limit <GAS_LIMIT> \
     --max-base-fee-per-gas <MAX_BASE_FEE_PER_GAS> \
-    --priority-fee-per-gas <PRIORITY_FEE_PER_GAS> \ 
+    --priority-fee-per-gas <PRIORITY_FEE_PER_GAS> \
     deposit withdraw \
     --operator <OPERATOR_ADDRESS> \
     --max-amount <MAX_AMOUNT>

--- a/docs/getting_started/transfer.md
+++ b/docs/getting_started/transfer.md
@@ -18,7 +18,7 @@ To create a transaction, you first need to know the `nonce` of your account, whi
     ```
 === "Windows"
     ```PowerShell
-    pchain_client.exe query nonce --address <YOUR_ACCOUNT_ADDRESS>
+    ./pchain_client.exe query nonce --address <YOUR_ACCOUNT_ADDRESS>
     ```
 When you run this command, you'll see the output of your account's `nonce` value, like this:
 ```bash
@@ -30,7 +30,7 @@ Next, to transfer tokens from your account to someone else's account using `pcha
 === "Linux / macOS"
     ```bash
     ./pchain_client transaction create \
-    --nonce <NONCE> \ 
+    --nonce <NONCE> \
     --gas-limit <GAS_LIMIT> \
     --max-base-fee-per-gas <MAX_BASE_FEE_PER_GAS> \
     --priority-fee-per-gas <PRIORITY_FEE_PER_GAS> \
@@ -40,13 +40,13 @@ Next, to transfer tokens from your account to someone else's account using `pcha
     ```
 === "Windows"
     ```PowerShell
-    pchain_client.exe transaction create \
-    --nonce <NONCE> \ 
-    --gas-limit <GAS_LIMIT> \
-    --max-base-fee-per-gas <MAX_BASE_FEE_PER_GAS> \
-    --priority-fee-per-gas <PRIORITY_FEE_PER_GAS> \ 
-    transfer \
-    --recipient <RECIPIENT_ADDRESS> \
+    ./pchain_client.exe transaction create `
+    --nonce <NONCE> `
+    --gas-limit <GAS_LIMIT> `
+    --max-base-fee-per-gas <MAX_BASE_FEE_PER_GAS> `
+    --priority-fee-per-gas <PRIORITY_FEE_PER_GAS> `
+    transfer `
+    --recipient <RECIPIENT_ADDRESS> `
     --amount <AMOUNT_TO_TRANSFER>
     ```
 
@@ -89,7 +89,7 @@ You can check the transaction status using `pchain_client` with the following co
     ```
 === "Windows"
     ```PowerShell
-    pchain_client.exe query tx --hash <TRANSACTION_HASH>
+    ./pchain_client.exe query tx --hash <TRANSACTION_HASH>
     ```
 
 Make sure to replace `<TRANSACTION_HASH>` with the transaction hash that you want to check.
@@ -109,10 +109,10 @@ You may append an extra transfer transaction with `pchain_client`. After creatin
     ```
 === "Windows"
     ```PowerShell
-    pchain_client.exe transaction append \
-    --file <PATH_TO_TRANSACTION_FILE>
-    transfer \
-    --recipient <RECIPIENT_ADDRESS> \
+    ./pchain_client.exe transaction append `
+    --file <PATH_TO_TRANSACTION_FILE> `
+    transfer `
+    --recipient <RECIPIENT_ADDRESS> `
     --amount <AMOUNT_TO_TRANSFER>
     ```
 

--- a/docs/smart_contract_sdk/call_contract.md
+++ b/docs/smart_contract_sdk/call_contract.md
@@ -44,28 +44,28 @@ Here is the command to call a contract:
 === "Linux / macOS"
     ```bash
     ./pchain_client transaction create \
-    --nonce <NONCE> \ 
+    --nonce <NONCE> \
     --gas-limit <GAS_LIMIT> \
     --max-base-fee-per-gas <MAX_BASE_FEE_PER_GAS> \
     --priority-fee-per-gas <PRIORITY_FEE_PER_GAS> \
     call \
-    --target <CONTRACT_ADDRESS> \   
+    --target <CONTRACT_ADDRESS> \
     --method <contract_METHOD> \
     --arguments <CALL_ARGUMENT_FILE_PATH_WITH_FILE_NAME>
     --amount <AMOUNT_TO_CONTRACT> \
     ```
 === "Windows"
     ```PowerShell
-    pchain_client.exe transaction create \
-    --nonce <NONCE> \ 
-    --gas-limit <GAS_LIMIT> \
-    --max-base-fee-per-gas <MAX_BASE_FEE_PER_GAS> \
-    --priority-fee-per-gas <PRIORITY_FEE_PER_GAS> \
-    call \
-    --target <CONTRACT_ADDRESS> \   
-    --method <contract_METHOD> \
-    --arguments <CALL_ARGUMENT_FILE_PATH_WITH_FILE_NAME>
-    --amount <AMOUNT_TO_CONTRACT> \
+    ./pchain_client.exe transaction create `
+    --nonce <NONCE> `
+    --gas-limit <GAS_LIMIT> `
+    --max-base-fee-per-gas <MAX_BASE_FEE_PER_GAS> `
+    --priority-fee-per-gas <PRIORITY_FEE_PER_GAS> `
+    call `
+    --target <CONTRACT_ADDRESS> `
+    --method <contract_METHOD> `
+    --arguments <CALL_ARGUMENT_FILE_PATH_WITH_FILE_NAME> `
+    --amount <AMOUNT_TO_CONTRACT>
     ```
 
 The gas limit required for the transaction depends on the complexity of the smart contract. For safety reasons, you can always set a higher gas limit. You can also test contract calls on testnet to reassure.
@@ -80,7 +80,7 @@ To query the resulting receipt of the transaction,
     ```
 === "Windows"
     ```PowerShell
-    pchain_client.exe query tx --hash <TRANSACTION_HASH>
+    ./pchain_client.exe query tx --hash <TRANSACTION_HASH>
     ```
 
 The commands stored in `transaction` and command receipts in `receipt` are following the same order. That means you can always find the corresponding transaction from a command receipt.
@@ -98,7 +98,7 @@ For example, if the contract method returns a u32 integer, the `return value` is
     ```
 === "Windows"
     ```PowerShell
-    pchain_client.exe parse call-result --value BAAAAAUAAAA --data-type u32
+    ./pchain_client.exe parse call-result --value BAAAAAUAAAA --data-type u32
     ```
 
 The output will be the parsed value of the `CallResult`, which in this case is `4`. For more details, you can use the `help` command to see the usage of the tool or take a look at the example `argument,json`.

--- a/docs/smart_contract_sdk/deploy_contract.md
+++ b/docs/smart_contract_sdk/deploy_contract.md
@@ -14,7 +14,7 @@ You can deploy the contract using the pchain_client command line tool. You shoul
 === "Linux / macOS"
     ```bash
     ./pchain_client transaction create
-    --nonce <NONCE> \ 
+    --nonce <NONCE> \
     --gas-limit <GAS_LIMIT> \
     --max-base-fee-per-gas <MAX_BASE_FEE_PER_GAS> \
     --priority-fee-per-gas <PRIORITY_FEE_PER_GAS> \
@@ -24,11 +24,11 @@ You can deploy the contract using the pchain_client command line tool. You shoul
     ```
 === "Windows"
     ```PowerShell
-    pchain_client.exe transaction create
-    --nonce <NONCE> \ 
+    ./pchain_client.exe transaction create
+    --nonce <NONCE> \
     --gas-limit <GAS_LIMIT> \
     --max-base-fee-per-gas <MAX_BASE_FEE_PER_GAS> \
-    --priority-fee-per-gas <PRIORITY_FEE_PER_GAS> \ 
+    --priority-fee-per-gas <PRIORITY_FEE_PER_GAS> \
     deploy \
     --contract-code <WASM_BINARY_PATH> \
     --cbi-version <CBI_VERSION> 
@@ -48,5 +48,5 @@ If you want to store the contract file in your preferred location, you need to p
     ```
 === "Windows"
     ```PowerShell
-    pchain_client.exe query contract --address <CONTRACT_ADDRESS>
+    ./pchain_client.exe query contract --address <CONTRACT_ADDRESS>
     ```


### PR DESCRIPTION
I fixed the powershell commands, so that they all start with ./
Additionally, I fixed whitespaces after \ for multiline commands on linux,
Finally, I fixed the mutliline delimiter for powershell from \ to `