### PR TITLE
Removed CMD instructions

### DIFF
--- a/docs/getting_started/installation.md
+++ b/docs/getting_started/installation.md
@@ -14,7 +14,7 @@ ParallelChain client (`pchain_client`) is a command-line tool that allows you to
 
 1. Download the latest release as a compressed file from Assets of ParallelChain Lab's GitHub [release page](https://github.com/parallelchain-io/pchain-client-cli/releases).
 2. Unzip the file to extract the executable `pchain_client.exe`.
-3. Open Command Prompt by pressing *WIN+R* and typing `cmd`.
+3. Open Powershell by pressing *WIN+R* and typing `powershell`.
 4. Navigate to the directory where `pchain_client.exe` is located using the `cd` command. For example, if the executable is located at `C:\Development`, type `cd C:\Development`.
 5. Follow the instructions in Section [Prepare Environment](prepare_env.md) to get ready for interacting with the blockchain.
 

--- a/docs/getting_started/prepare_env.md
+++ b/docs/getting_started/prepare_env.md
@@ -28,12 +28,6 @@ The following command will set the environmental variable **temporarily**:
     # For example, "C:\Users\user\pchain_cli_home"
     $Env:PCHAIN_CLI_HOME="<PATH_TO_DIRECTORY>"
     ```
-=== "Windows Command Prompt"
-    ```PowerShell
-    # For example, C:\Users\user\pchain_cli_home
-    # No parentheses required
-    set PCHAIN_CLI_HOME=<PATH_TO_DIRECTORY>
-    ```
 
 For convenience reasons, you may alternatively want to set environmental **permanently**. Even in that case, we still suggest you remember the storage location.
 


### PR DESCRIPTION
Remove or replaced instructions for CMD and replace them with powershell for windows.

The rest of the documentation is powershell only, this will prevent confusion