### PR TITLE
ci: 🎡 deploys previews of pull requests to GitHub Pages

### DIFF
--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -1,0 +1,37 @@
+name: 🚀 Preview
+
+concurrency: preview-${{ github.ref }}
+
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - closed
+
+jobs:
+  preview:
+    name: 🚀 Preview
+    runs-on: ubuntu-latest
+    steps:
+      - name: 🛑 Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.11.0
+
+      - name: ⬇️ Checkout
+        uses: actions/checkout@v3
+
+      - name: 🐍 Python
+        uses: actions/setup-python@v4
+
+      - name: 🎈 Install and Build
+        run: |
+          pip install --upgrade pip
+          pip install mkdocs pymdown-extensions mkdocs-material
+          mkdocs build
+
+      - name: 🚀 Deploy
+        uses: rossjrw/pr-preview-action@v1
+        with:
+          source-dir: ./site/
+


### PR DESCRIPTION
Support preview for pull requests.

Features:
- Creates and deploys previews of pull requests to your GitHub Pages site
- Leaves a comment on the pull request with a link to the preview so that you and your team can collaborate on new features faster
- Updates the deployment and the comment whenever new commits are pushed to the pull request
- Cleans up after itself — removes deployed previews when the pull request is closed

Preview URLs look like this: https://[owner].github.io/[repo]/pr-preview/pr-[number]/