### PR TITLE
ci: 🎡 permission write

### DIFF
--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -9,7 +9,8 @@ on:
       - reopened
       - synchronize
       - closed
-
+permissions:
+    pull-requests: write
 jobs:
   preview:
     name: 🚀 Preview

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -10,6 +10,7 @@ on:
       - synchronize
       - closed
 permissions:
+    contents: write
     pull-requests: write
 jobs:
   preview:


### PR DESCRIPTION
related to https://github.com/marocchino/sticky-pull-request-comment#error-resource-not-accessible-by-integration