### PR TITLE
Updated pchain_client_cli related commands in docs

### DIFF
--- a/docs/getting_started/create_account.md
+++ b/docs/getting_started/create_account.md
@@ -15,11 +15,11 @@ The guide will walk you through the steps to generate and manage your Mainnet / 
 To create an account, type the following command below:
 === "Linux / macOS"
     ```bash
-    ./pchain_client keys create --name <NAME>
+    ./pchain_client keys create --keypair-name <KEYPAIR_NAME>
     ```
 === "Windows PowerShell"
     ```PowerShell
-    ./pchain_client.exe keys create --name <NAME>
+    ./pchain_client.exe keys create --keypair-name <KEYPAIR_NAME>
     ```
 
 You will be asked to input your password to save the new keypair.
@@ -70,11 +70,11 @@ To secure your keypair and money, you must export it and save it somewhere secur
 
 === "Linux / macOS"
     ```bash
-    ./pchain_client keys export --name <NAME>
+    ./pchain_client keys export --keypair-name <KEYPAIR_NAME>
     ```
 === "Windows PowerShell"
     ```PowerShell
-    ./pchain_client.exe keys export --name <NAME>
+    ./pchain_client.exe keys export --keypair-name <KEYPAIR_NAME>
     ```
 
 You will be asked to input your password to export the keypair. The keypair will be saved in the current directory, in JSON format, with the same name as the keypair itself.
@@ -84,11 +84,11 @@ You will be asked to input your password to export the keypair. The keypair will
 To add your keypair, type the following command below:
 === "Linux / macOS"
     ```bash
-    ./pchain_client keys import --public <PUBLIC_KEY/ADDRESS> --private <PRIVATE_KEY> --name <NAME>
+    ./pchain_client keys import --public <PUBLIC_KEY/ADDRESS> --private <PRIVATE_KEY> --keypair-name <KEYPAIR_NAME>
     ```
 === "Windows PowerShell"
     ```PowerShell
-    ./pchain_client.exe keys import --public <PUBLIC_KEY/ADDRESS> --private <PRIVATE_KEY> --name <NAME>
+    ./pchain_client.exe keys import --public <PUBLIC_KEY/ADDRESS> --private <PRIVATE_KEY> --keypair-name <KEYPAIR_NAME>
     ```
 
 You will be asked to input your password to import the new keypair.

--- a/docs/getting_started/staking.md
+++ b/docs/getting_started/staking.md
@@ -17,6 +17,7 @@ First, before you stake, you have to lock up (stake) some balance tied to an ope
 === "Linux / macOS"
     ```bash
     ./pchain_client transaction create \
+    <--v1|--v2> \
     --nonce <NONCE> \
     --gas-limit <GAS_LIMIT> \
     --max-base-fee-per-gas <MAX_BASE_FEE_PER_GAS> \
@@ -29,6 +30,7 @@ First, before you stake, you have to lock up (stake) some balance tied to an ope
 === "Windows PowerShell"
     ```PowerShell
     ./pchain_client.exe transaction create `
+    <--v1|--v2> `
     --nonce <NONCE> `
     --gas-limit <GAS_LIMIT> `
     --max-base-fee-per-gas <MAX_BASE_FEE_PER_GAS> `
@@ -57,6 +59,7 @@ After creating a Deposit in a Pool, use the CLI subcommands `deposit top-up` if 
 === "Linux / macOS"
     ```bash
     ./pchain_client transaction create \
+    <--v1|--v2> \
     --nonce <NONCE> \
     --gas-limit <GAS_LIMIT> \
     --max-base-fee-per-gas <MAX_BASE_FEE_PER_GAS> \
@@ -68,6 +71,7 @@ After creating a Deposit in a Pool, use the CLI subcommands `deposit top-up` if 
 === "Windows PowerShell"
     ```PowerShell
     ./pchain_client.exe transaction create `
+    <--v1|--v2> `
     --nonce <NONCE> `
     --gas-limit <GAS_LIMIT> `
     --max-base-fee-per-gas <MAX_BASE_FEE_PER_GAS> `
@@ -85,6 +89,7 @@ You specified the flag `auto-stake-rewards` when you created the Deposit. You ca
 === "Linux / macOS"
     ```bash
     ./pchain_client transaction create \
+    <--v1|--v2> \
     --nonce <NONCE> \
     --gas-limit <GAS_LIMIT> \
     --max-base-fee-per-gas <MAX_BASE_FEE_PER_GAS> \
@@ -96,6 +101,7 @@ You specified the flag `auto-stake-rewards` when you created the Deposit. You ca
 === "Windows PowerShell"
     ```PowerShell
     ./pchain_client.exe transaction create `
+    <--v1|--v2> `
     --nonce <NONCE> `
     --gas-limit <GAS_LIMIT> `
     --max-base-fee-per-gas <MAX_BASE_FEE_PER_GAS> `
@@ -113,6 +119,7 @@ After you create a Deposit to a Pool, you should now stake some amount of it to 
 === "Linux / macOS"
     ```bash
     ./pchain_client transaction create \
+    <--v1|--v2> \
     --nonce <NONCE> \
     --gas-limit <GAS_LIMIT> \
     --max-base-fee-per-gas <MAX_BASE_FEE_PER_GAS> \
@@ -124,6 +131,7 @@ After you create a Deposit to a Pool, you should now stake some amount of it to 
 === "Windows PowerShell"
     ```PowerShell
     ./pchain_client.exe transaction create `
+    <--v1|--v2> `
     --nonce <NONCE> `
     --gas-limit <GAS_LIMIT> `
     --max-base-fee-per-gas <MAX_BASE_FEE_PER_GAS> `
@@ -140,6 +148,7 @@ You can also unstake your stake on with the CLI subcommand `stake unstake`.
 === "Linux / macOS"
     ```bash
     ./pchain_client transaction create \
+    <--v1|--v2> \
     --nonce <NONCE> \
     --gas-limit <GAS_LIMIT> \
     --max-base-fee-per-gas <MAX_BASE_FEE_PER_GAS> \
@@ -151,6 +160,7 @@ You can also unstake your stake on with the CLI subcommand `stake unstake`.
 === "Windows PowerShell"
     ```PowerShell
     ./pchain_client.exe transaction create `
+    <--v1|--v2> `
     --nonce <NONCE> `
     --gas-limit <GAS_LIMIT> `
     --max-base-fee-per-gas <MAX_BASE_FEE_PER_GAS> `
@@ -193,6 +203,7 @@ Your Deposit can be increased due to reward distribution in each epoch. If you w
 === "Linux / macOS"
     ```bash
     ./pchain_client transaction create \
+    <--v1|--v2> \
     --nonce <NONCE> \
     --gas-limit <GAS_LIMIT> \
     --max-base-fee-per-gas <MAX_BASE_FEE_PER_GAS> \
@@ -204,6 +215,7 @@ Your Deposit can be increased due to reward distribution in each epoch. If you w
 === "Windows PowerShell"
     ```PowerShell
     ./pchain_client.exe transaction create `
+    <--v1|--v2> `
     --nonce <NONCE> `
     --gas-limit <GAS_LIMIT> `
     --max-base-fee-per-gas <MAX_BASE_FEE_PER_GAS> `

--- a/docs/getting_started/transfer.md
+++ b/docs/getting_started/transfer.md
@@ -25,11 +25,12 @@ When you run this command, you'll see the output of your account's `nonce` value
 0
 ```
 
-Next, to transfer tokens from your account to someone else's account using `pchain_client`, you need to create a transaction file containing one transfer command first. 
+Next, to transfer tokens from your account to someone else's account using `pchain_client`, you need to create a transaction file containing one transfer command first.
 
 === "Linux / macOS"
     ```bash
     ./pchain_client transaction create \
+    <--v1|--v2> \
     --nonce <NONCE> \
     --gas-limit <GAS_LIMIT> \
     --max-base-fee-per-gas <MAX_BASE_FEE_PER_GAS> \
@@ -41,6 +42,7 @@ Next, to transfer tokens from your account to someone else's account using `pcha
 === "Windows PowerShell"
     ```PowerShell
     ./pchain_client.exe transaction create `
+    <--v1|--v2> `
     --nonce <NONCE> `
     --gas-limit <GAS_LIMIT> `
     --max-base-fee-per-gas <MAX_BASE_FEE_PER_GAS> `
@@ -116,6 +118,6 @@ You may append an extra transfer transaction with `pchain_client`. After creatin
     --amount <AMOUNT_TO_TRANSFER>
     ```
 
-Currently, if you construct a transaction with `pchain_client`, the fields `nonce`, `gas limit`, `max base fee per gas` and `priority fee per gas` are already filled in after calling command `create`. You need to manually change the transaction JSON file if you want to change them:
+Once you have constructed a transaction using the `pchain_client transaction create` command, the fields in the JSON file will be populated. If necessary, you have the option to manually modify the transaction JSON file.
 
-After chaining up commands you are satisfied with, you can submit the transaction as you did in a single command transaction.
+Once you have successfully chained together the desired commands, you can submit the transaction just as you would with a single command transaction.

--- a/docs/smart_contract_sdk/call_contract.md
+++ b/docs/smart_contract_sdk/call_contract.md
@@ -44,6 +44,7 @@ Here is the command to call a contract:
 === "Linux / macOS"
     ```bash
     ./pchain_client transaction create \
+    <--v1|--v2> \
     --nonce <NONCE> \
     --gas-limit <GAS_LIMIT> \
     --max-base-fee-per-gas <MAX_BASE_FEE_PER_GAS> \
@@ -57,6 +58,7 @@ Here is the command to call a contract:
 === "Windows PowerShell"
     ```PowerShell
     ./pchain_client.exe transaction create `
+    <--v1|--v2> `
     --nonce <NONCE> `
     --gas-limit <GAS_LIMIT> `
     --max-base-fee-per-gas <MAX_BASE_FEE_PER_GAS> `

--- a/docs/smart_contract_sdk/deploy_contract.md
+++ b/docs/smart_contract_sdk/deploy_contract.md
@@ -14,6 +14,7 @@ You can deploy the contract using the pchain_client command line tool. You shoul
 === "Linux / macOS"
     ```bash
     ./pchain_client transaction create
+    <--v1|--v2> \
     --nonce <NONCE> \
     --gas-limit <GAS_LIMIT> \
     --max-base-fee-per-gas <MAX_BASE_FEE_PER_GAS> \
@@ -25,6 +26,7 @@ You can deploy the contract using the pchain_client command line tool. You shoul
 === "Windows PowerShell"
     ```PowerShell
     ./pchain_client.exe transaction create `
+    <--v1|--v2> `
     --nonce <NONCE> `
     --gas-limit <GAS_LIMIT> `
     --max-base-fee-per-gas <MAX_BASE_FEE_PER_GAS> `

--- a/docs/toolings/pchain_cli/install_and_setup.md
+++ b/docs/toolings/pchain_cli/install_and_setup.md
@@ -10,22 +10,17 @@ tags:
 ## Installation
 ---
 
-`pchain_client` is an available tool for users on Unix/Linux, MacOS, and Windows operating systems. Simply download the pre-built binary corresponding to your platform and install the `pchain_client`.
+The `pchain_client` tool is accessible to users operating on Unix/Linux, MacOS, and Windows systems. To install `pchain_client`, simply download the pre-built binary that corresponds to your specific platform and proceed with the installation. Here are the straightforward steps to follow:
 
-Here are the simple steps to install `pchain_client`:
+1. Open a web browser and navigate to the [release page](https://github.com/parallelchain-io/pchain-client-cli/releases).
+2. Locate and download the pre-built binary that is compatible with your platform.
+3. Execute the downloaded file to initiate the installation process.
 
-- Open a web browser and go to [release page](https://github.com/parallelchain-io/pchain-client-cli/releases).
-- Follow the link to download pre-built binary available for your platform.
-- Run the downloaded file.
-
-**NOTE:**
-If this is your first time using `pchain_client`, you need to setup `$PCHAIN_CLI_HOME` in environment variables to specify the home path. See more [here](https://chlee.co/how-to-setup-environment-variables-for-windows-mac-and-linux/).
+Please note that if this is your first time using `pchain_client`, it is necessary to set up the `$PCHAIN_CLI_HOME` environment variable to specify the home path. For detailed instructions on setting up environment variables on Windows, Mac, and Linux systems, please refer to this resource: [here](https://chlee.co/how-to-setup-environment-variables-for-windows-mac-and-linux/).
 
 ## Running pchain_client
 ---
-
-Upon first use of `pchain_client`, you will be prompted to set up a password to protect your account keypairs. Please note that this password can be different from the password you used in ParallelChain Explorer. Alternatively, you can skip the password protection by simply pressing Enter.
-
+To check if `pchain_client` is intalled properly, run the following command:
 === "Linux / macOS"
     ```bash
     ./pchain_client --version
@@ -34,6 +29,9 @@ Upon first use of `pchain_client`, you will be prompted to set up a password to 
     ```PowerShell
     ./pchain_client.exe --version
     ```
+
+Upon first use of `pchain_client`, you will be prompted to set up a password to protect your account keypairs. Please note that this password can be different from the password you used in ParallelChain Explorer. Alternatively, you can skip the password protection by simply pressing Enter.
+
 You will be required to enter your password twice. If your password is set successfully, you will see a return message with `pchain_client` version shown on console.
 
 **WARNING:**

--- a/docs/toolings/pchain_cli/introduction.md
+++ b/docs/toolings/pchain_cli/introduction.md
@@ -14,7 +14,7 @@ For a detailed description of all available commands, execute `pchain_client --h
 ---
 
 ```terminal
-ParallelChain Client CLI 0.4.3
+ParallelChain Client CLI 0.5.0
 <ParallelChain Lab>
 ParallelChain client (`pchain_client`) is a command-line tool for you to connect and interact with
 the ParallelChain Mainnet/Testnet.

--- a/docs/toolings/pchain_cli/manage_account.md
+++ b/docs/toolings/pchain_cli/manage_account.md
@@ -16,11 +16,11 @@ This command generates a set of ed25519_dalek compatible keys. Random name will 
 
 === "Linux / macOS"
     ```bash
-    ./pchain_client keys create --name <NAME>
+    ./pchain_client keys create --keypair-name <KEYPAIR_NAME>
     ```
 === "Windows PowerShell"
     ```PowerShell
-    ./pchain_client.exe keys create --name <NAME>
+    ./pchain_client.exe keys create --keypair-name <KEYPAIR_NAME>
     ```
 
 
@@ -29,11 +29,11 @@ If you have already got keys from ParallelChain Explorer, you can import your ac
 
 === "Linux / macOS"
     ```bash
-    ./pchain_client keys import --private <PRIVATE_KEY> --public <PUBLIC_KEY/ADDRESS> --name <NAME>
+    ./pchain_client keys import --private <PRIVATE_KEY> --public <PUBLIC_KEY/ADDRESS> --keypair-name <KEYPAIR_NAME>
     ```
 === "Windows PowerShell"
     ```PowerShell
-    ./pchain_client.exe keys import --private <PRIVATE_KEY> --public <PUBLIC_KEY/ADDRESS> --name <NAME>
+    ./pchain_client.exe keys import --private <PRIVATE_KEY> --public <PUBLIC_KEY/ADDRESS> --keypair-name <KEYPAIR_NAME>
     ```
 
 `PRIVATE_KEY` and `PUBLIC_KEY/ADDRESS` are Base64url encoded.

--- a/docs/toolings/pchain_cli/manage_account.md
+++ b/docs/toolings/pchain_cli/manage_account.md
@@ -9,10 +9,10 @@ tags:
 ## Manage Account
 ---
 
-In ParallelChain, an account is identified by the public key of Ed25519 keypair. You can either generate new keys or import your existing Ed25519 keypair to make transactions in `pchain_client`. Both operations require password (if you setup before).
+In ParallelChain, an account is uniquely identified by the public key of an Ed25519 keypair. To perform transactions in `pchain_client`, you have the option to either generate new keys or import an existing Ed25519 keypair. In both cases, you will need to provide the password if you have previously set one up.
 
 ### Generate New Keypair
-This command generates a set of ed25519_dalek compatible keys. Random name will be set if you do not provide a name.
+This command generates a set of ed25519_dalek compatible keys. A random name will be assigned if you do not provide a name.
 
 === "Linux / macOS"
     ```bash
@@ -25,7 +25,7 @@ This command generates a set of ed25519_dalek compatible keys. Random name will 
 
 
 ### Import Existing Keypair
-If you have already got keys from ParallelChain Explorer, you can import your account keypair with this command. Random name will be set if you do not provide a name.
+To import your account keypair obtained from ParallelChain Explorer, you can use the following command. Random name will be set if you do not provide a name.
 
 === "Linux / macOS"
     ```bash
@@ -39,7 +39,7 @@ If you have already got keys from ParallelChain Explorer, you can import your ac
 `PRIVATE_KEY` and `PUBLIC_KEY/ADDRESS` are Base64url encoded.
 
 ### List Accounts
-After creating or adding keypair, you can check it using the following command to list out all public keys managed in this tool.
+After creating or importing a keypair, you can utilize the following command to display a list of all the public keys managed within this tool.
 
 === "Linux / macOS"
     ```bash

--- a/docs/toolings/pchain_cli/smart_contract.md
+++ b/docs/toolings/pchain_cli/smart_contract.md
@@ -20,11 +20,27 @@ Command:
 
 === "Linux / macOS"
     ```bash
-    ./pchain_client parse contract-address --address <ADDRESS> --nonce <NONCE>
+    # To parse the first version of contract address which is defined in
+    # ParallelChain Protocol V0.4
+
+    ./pchain_client parse contract-address v1 --address <ADDRESS> --nonce <NONCE>
+    
+    # To parse the second version of contract address which defined in
+    # ParallelChain Protocol V0.5
+
+    ./pchain_client parse contract-address v2 --address <ADDRESS> --nonce <NONCE> --deploy_cmd_index <INDEX>
     ```
 === "Windows PowerShell"
     ```PowerShell
-    ./pchain_client.exe parse contract-address --address <ADDRESS> --nonce <NONCE>
+    # To parse the first version of contract address which is defined in
+    # ParallelChain Protocol V0.4
+
+    ./pchain_client parse contract-address v1 --address <ADDRESS> --nonce <NONCE>
+    
+    # To parse the second version of contract address which defined in
+    # ParallelChain Protocol V0.5
+    
+    ./pchain_client parse contract-address v2 --address <ADDRESS> --nonce <NONCE> --deploy_cmd_index <INDEX>
     ```
 
 ### Prepare Contract Method Arguments File

--- a/docs/toolings/pchain_cli/transaction.md
+++ b/docs/toolings/pchain_cli/transaction.md
@@ -49,10 +49,11 @@ Here are some CLI subcommands to indicate corresponding Protocol Transaction Com
     ```
 
 
-First, provide the following 4 parameters:
+First, decide the version of the transaction that you are creating with the flags `--v1` and `--v2`, then provide the following 4 parameters:
 === "Linux / macOS"
     ```bash
     ./pchain_client transaction create \
+      <--v1|--v2> \
       --nonce <NONCE> \
       --gas-limit <GAS_LIMIT> \
       --max-base-fee-per-gas <MAX_BASE_FEE_PER_GAS> \
@@ -62,6 +63,7 @@ First, provide the following 4 parameters:
 === "Windows PowerShell"
     ```PowerShell
     ./pchain_client.exe transaction create `
+      <--v1|--v2> `
       --nonce <NONCE> `
       --gas-limit <GAS_LIMIT> `
       --max-base-fee-per-gas <MAX_BASE_FEE_PER_GAS> `
@@ -71,12 +73,13 @@ First, provide the following 4 parameters:
 
 Then, decide the transaction type using the [CLI subcommand](#prepare-transaction-file). Each of them takes different inputs. You can always check the help menu using `--help`.
 
-Make sure you provide both `Parameters` and `Subcommand` parts in one command. The output transaction file (tx.json) will be saved in the current directory. You can also specify the designated file with the flag `--destination`
+Make sure you provide both `Parameters` and `Subcommand` parts in one command. The output transaction file (tx.json) will be saved in the current directory. You can also specify the designated file with the flag `--destination`.
 
 Example - Transfer tokens:
 === "Linux / macOS"
     ```bash
     ./pchain_client transaction create \
+      --v2 \
       --nonce 0 \
       --gas-limit 100000 \
       --max-base-fee-per-gas 8 \
@@ -88,6 +91,7 @@ Example - Transfer tokens:
 === "Windows PowerShell"
     ```PowerShell
     ./pchain_client.exe transaction create `
+      --v2 `
       --nonce 0 `
       --gas-limit 100000 `
       --max-base-fee-per-gas 8 `
@@ -102,6 +106,7 @@ Example - Deploy contract and save to designated file `deposit-tx.json`:
     ```bash
     ./pchain_client transaction create \
     --destination ~/Documents/deposit-tx.json \
+    --v2 \
     --nonce 0 \
     --gas-limit 100000 \
     --max-base-fee-per-gas 8 \
@@ -114,6 +119,7 @@ Example - Deploy contract and save to designated file `deposit-tx.json`:
     ```PowerShell
     ./pchain_client.exe transaction create `
     --destination ~/Documents/deposit-tx.json `
+    --v2 `
     --nonce 0 `
     --gas-limit 100000 `
     --max-base-fee-per-gas 8 `


### PR DESCRIPTION
- Added `--v1` and `--v2` tags in `pchain_client transaction create` and `pchain_client parse contract_address` commands
- Renamed `--name` to `--keypair-name` for `pchain_client keys` commands
- general rephrase