### PR TITLE
Fix LaTeX rendering

### DIFF
--- a/docs/javascripts/mathjax.js
+++ b/docs/javascripts/mathjax.js
@@ -1,0 +1,22 @@
+// This file is used by mkdocs.yml to install MathJax into the website, allowing LaTeX in Markdown
+// documents to be rendered.
+
+window.MathJax = {
+    tex: {
+      inlineMath: [["\\(", "\\)"]],
+      displayMath: [["\\[", "\\]"]],
+      processEscapes: true,
+      processEnvironments: true
+    },
+    options: {
+      ignoreHtmlClass: ".*|",
+      processHtmlClass: "arithmatex"
+    }
+  };
+  
+document$.subscribe(() => { 
+    MathJax.startup.output.clearCache()
+    MathJax.typesetClear()
+    MathJax.texReset()
+    MathJax.typesetPromise()
+})

--- a/docs/js/index.js
+++ b/docs/js/index.js
@@ -1,4 +1,0 @@
-
-function a() {
-    return 1;
-}


### PR DESCRIPTION
The LaTeX in the "/fundamentals/staking" page is currently broken (rendered as plaintext). This PR aims to render them properly.